### PR TITLE
Support openssl1.1

### DIFF
--- a/lib/money-tree/version.rb
+++ b/lib/money-tree/version.rb
@@ -1,3 +1,3 @@
 module MoneyTree
-  VERSION = "0.10.1"
+  VERSION = "0.10.2"
 end

--- a/lib/openssl_extensions.rb
+++ b/lib/openssl_extensions.rb
@@ -6,7 +6,7 @@ require 'ffi'
 module MoneyTree
   module OpenSSLExtensions
     extend FFI::Library
-    ffi_lib ['libssl.so.1.1.1', 'libssl.so.11', 'libssl1.1.1', 'libssl.1.1.1', 'ssl']
+    ffi_lib ['libssl.so.1.1.1', 'libssl.so.11', 'libssl1.1.1', 'libssl.1.1', 'ssl']
 
     NID_secp256k1 = 714
     POINT_CONVERSION_COMPRESSED = 2

--- a/lib/openssl_extensions.rb
+++ b/lib/openssl_extensions.rb
@@ -6,7 +6,7 @@ require 'ffi'
 module MoneyTree
   module OpenSSLExtensions
     extend FFI::Library
-    ffi_lib ['libssl.so.1.0.0', 'libssl.so.10', 'libssl1.0.0', 'libssl.1.0.0', 'ssl']
+    ffi_lib ['libssl.so.1.1.1', 'libssl.so.11', 'libssl1.1.1', 'libssl.1.1.1', 'ssl']
 
     NID_secp256k1 = 714
     POINT_CONVERSION_COMPRESSED = 2
@@ -20,12 +20,12 @@ module MoneyTree
     attach_function :EC_POINT_point2hex, [:pointer, :pointer, :int, :pointer], :string
     attach_function :EC_POINT_hex2point, [:pointer, :string, :pointer, :pointer], :pointer
     attach_function :EC_POINT_new, [:pointer], :pointer
-    
+
     def self.add(point_0, point_1)
       validate_points(point_0, point_1)
       eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
       group = EC_KEY_get0_group(eckey)
-      
+
       point_0_hex = point_0.to_bn.to_s(16)
       point_0_pt = EC_POINT_hex2point(group, point_0_hex, nil, nil)
       point_1_hex = point_1.to_bn.to_s(16)
@@ -52,9 +52,9 @@ module MoneyTree
     def self.validate_points(*points)
       points.each do |point|
         if !point.is_a?(OpenSSL::PKey::EC::Point)
-          raise ArgumentError, "point must be an OpenSSL::PKey::EC::Point object" 
+          raise ArgumentError, "point must be an OpenSSL::PKey::EC::Point object"
         elsif point.infinity?
-          raise ArgumentError, "point must not be infinity" 
+          raise ArgumentError, "point must not be infinity"
         end
       end
     end
@@ -64,10 +64,10 @@ end
 
 class OpenSSL::PKey::EC::Point
   include MoneyTree::OpenSSLExtensions
-  
+
   def add(point)
     sum_point_hex = MoneyTree::OpenSSLExtensions.add(self, point)
     self.class.new group, OpenSSL::BN.new(sum_point_hex, 16)
   end
-  
+
 end


### PR DESCRIPTION
No clue if the syntax for `libssl.so.1.1.1`, `libssl.so.11`, `libssl1.1.1` is right, but `libssl.1.1` works on OSX with OpenSSL 1.1.1. 